### PR TITLE
Add $ to span only if $ is not in a lookforward

### DIFF
--- a/test/regression/matlab/test_multiple_inheritance_ml.m
+++ b/test/regression/matlab/test_multiple_inheritance_ml.m
@@ -1,0 +1,14 @@
+classdef test_multiple_inheritance < handle & another_class ...
+    & another_class_2
+    properties
+        Value {mustBeNumeric}
+    end
+    methods
+        function r = roundOff(obj)
+            r = round([obj.Value],2);
+        end
+        function r = multiplyBy(obj,n)
+            r = [obj.Value]*n;
+        end
+    end
+end

--- a/test/regression/test_matlab.py
+++ b/test/regression/test_matlab.py
@@ -21,6 +21,9 @@ test_files = [
         "lineContinuations",
         "PropertyValidation",
     ]
+] + [
+    str(Path(__file__).parent.resolve() / "matlab" / (file + ".m"))
+    for file in ["test_multiple_inheritance_ml"]
 ]
 
 


### PR DESCRIPTION
When a pattern includes the EOL character `$`, the handler ensures that the newline character is included in the matching span. This ensures that pattern search continues on the next line.
https://github.com/watermarkhu/textmate-grammar-python/blob/0049d3735717227a6d6436d4b65141be14d5f1b1/textmate_grammar/handler.py#L204-L207

However, this should not happen if `$` is in a lookforward, such as in:
https://github.com/watermarkhu/textmate-grammar-python/blob/0049d3735717227a6d6436d4b65141be14d5f1b1/textmate_grammar/grammars/matlab/grammar.yaml#L282

Resolves #9 